### PR TITLE
Expose create_input function

### DIFF
--- a/tests/test_create_input.py
+++ b/tests/test_create_input.py
@@ -1,0 +1,14 @@
+import torch
+import torchtrail
+
+
+def test_create_input():
+    tensor = torch.rand(1, 64)
+    with torchtrail.trace():
+        traced_tensor = torchtrail.create_input(tensor)
+        output = torch.exp(traced_tensor)
+
+    torchtrail.visualize(output)
+    assert len(torchtrail.get_graph(output)) == 2
+    codegen_output = torchtrail.codegen(output)
+    assert len(codegen_output.split("\n")) == 6

--- a/torchtrail/__init__.py
+++ b/torchtrail/__init__.py
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .tracer import trace, visualize, get_graph
+from .tracer import trace, visualize, get_graph, create_input
 from .codegen import codegen

--- a/torchtrail/tracer.py
+++ b/torchtrail/tracer.py
@@ -325,6 +325,15 @@ def create_input_tensor(
         raise RuntimeError(f"Unknown input type: {type(tensor)}")
 
 
+def create_input(tensor: torch.Tensor) -> TracedTorchTensor:
+    """Register a tensor created outside the trace as an input."""
+
+    if not is_tracing_enabled():
+        raise RuntimeError("Tracing must be enabled to call create_input")
+
+    return create_input_tensor(tensor)
+
+
 def preprocess_args_and_kwargs(*function_args, **function_kwargs) -> Any:
     def preprocess_arg(argument: Any) -> Any:
         if isinstance(argument, TracedTensorTrait):


### PR DESCRIPTION
## Summary
- expose `create_input` through the top-level API
- implement `create_input` helper in tracer
- add a regression test using `torchtrail.create_input`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*