### PR TITLE
Fix variable typo and add nested trace test

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -72,7 +72,7 @@ def test_module_list_with_multiple_traces():
     assert len(torchtrail.get_graph(output)) == 2
     assert len(torchtrail.get_graph(output, flatten=True)) == 13
 
-    ingored_output = module(
+    ignored_output = module(
         input_tensor
     )  # Output outside the context manager won't be traced
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,11 @@
+import pytest
+
+import torchtrail
+
+
+def test_nested_trace_error():
+    with torchtrail.trace():
+        with pytest.raises(RuntimeError):
+            with torchtrail.trace():
+                pass
+


### PR DESCRIPTION
## Summary
- fix a variable name typo in `test_modules.py`
- add a new `test_tracer.py` file to check that nested `torchtrail.trace()` raises `RuntimeError`

## Testing
- `pytest -q` *(fails: URLError/requests.exceptions due to no network)*