### PR TITLE
Fix spelling in tracer comment

### DIFF
--- a/torchtrail/tracer.py
+++ b/torchtrail/tracer.py
@@ -42,7 +42,7 @@ GRAPH_STACK = None
 TORCH_NN_MODULE_CALL = torch.nn.Module.__call__
 
 
-# The following functions are overriden to capture input tensors
+# The following functions are overridden to capture input tensors
 TORCH_CREATION_OPERATION_NAMES = [
     "as_tensor",
     "from_numpy",


### PR DESCRIPTION
## Summary
- fix typo in torchtrail tracer comment

## Testing
- `pytest -q` *(fails: urllib/requests errors due to network)*