### PR TITLE
Expose create_input function

### DIFF
--- a/tests/test_create_input.py
+++ b/tests/test_create_input.py
@@ -1,0 +1,14 @@
+import torch
+import torchtrail
+
+
+def test_create_input():
+    tensor = torch.rand(1, 64)
+    with torchtrail.trace():
+        traced_tensor = torchtrail.create_input(tensor)
+        output = torch.exp(traced_tensor)
+
+    torchtrail.visualize(output)
+    assert len(torchtrail.get_graph(output)) == 2
+    codegen_output = torchtrail.codegen(output)
+    assert len(codegen_output.split("\n")) == 6

--- a/torchtrail/__init__.py
+++ b/torchtrail/__init__.py
@@ -20,5 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .tracer import trace, visualize, get_graph
+from .tracer import trace, visualize, get_graph, create_input_tensor
+
+# expose create_input_tensor under a simpler name for convenience
+create_input = create_input_tensor
 from .codegen import codegen


### PR DESCRIPTION
## Summary
- expose `create_input_tensor` via torchtrail.create_input
- remove redundant wrapper function
- keep regression test for registering tensors before trace

## Testing
- `pytest -q --maxfail=1` *(fails: ProxyError: unable to connect to proxy)*
- `pytest tests/test_create_input.py -q`
