### PR TITLE
Fix tests for offline environment

### DIFF
--- a/tests/test_bert.py
+++ b/tests/test_bert.py
@@ -8,8 +8,12 @@ import torchtrail
 
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_bert_attention(tmp_path, show_modules):
-    model_name = "google/bert_uncased_L-4_H-256_A-4"
-    config = transformers.BertConfig.from_pretrained(model_name)
+    config = transformers.BertConfig(
+        hidden_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        intermediate_size=1024,
+    )
     model = transformers.models.bert.modeling_bert.BertAttention(config).eval()
 
     with torchtrail.trace():
@@ -28,8 +32,13 @@ def test_bert_attention(tmp_path, show_modules):
 
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_bert(tmp_path, show_modules):
-    model_name = "google/bert_uncased_L-4_H-256_A-4"
-    model = transformers.BertModel.from_pretrained(model_name).eval()
+    config = transformers.BertConfig(
+        hidden_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        intermediate_size=1024,
+    )
+    model = transformers.BertModel(config).eval()
 
     with torchtrail.trace():
         input_tensor = torch.randint(0, model.config.vocab_size, (1, 64))

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -1,36 +1,16 @@
 import pytest
 
-import urllib
-
 import torch
-from PIL import Image
-from torchvision import transforms
+from torchvision import models
 
 import torchtrail
 
 
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_resnet(tmp_path, show_modules):
-    model = torch.hub.load("pytorch/vision:v0.10.0", "resnet18", pretrained=True).eval()
+    model = models.resnet18(weights=None).eval()
 
-    url = "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
-    filename = tmp_path / "dog.jpg"
-
-    try:
-        urllib.URLopener().retrieve(url, filename)
-    except Exception:
-        urllib.request.urlretrieve(url, filename)
-
-    input_image = Image.open(filename)
-    preprocess = transforms.Compose(
-        [
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ]
-    )
-    input_tensor = preprocess(input_image).unsqueeze(0)
+    input_tensor = torch.randn(1, 3, 224, 224)
 
     with torchtrail.trace():
         input_tensor = torch.as_tensor(input_tensor)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -8,4 +8,3 @@ def test_nested_trace_error():
         with pytest.raises(RuntimeError):
             with torchtrail.trace():
                 pass
-

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -8,13 +8,19 @@ import torchtrail
 
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_vit_embeddings(tmp_path, show_modules):
-    model_name = "google/vit-base-patch16-224"
     batch_size = 1
     num_channels = 3
     height = 224
     width = 224
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTEmbeddings(config).eval()
 
     with torchtrail.trace():
@@ -37,7 +43,14 @@ def test_vit_self_attention(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTSelfAttention(config).eval()
 
     with torchtrail.trace():
@@ -60,7 +73,14 @@ def test_vit_self_output(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTSelfOutput(config).eval()
 
     with torchtrail.trace():
@@ -84,7 +104,14 @@ def test_vit_attention(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTAttention(config).eval()
 
     with torchtrail.trace():
@@ -107,7 +134,14 @@ def test_vit_intermediate(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTIntermediate(config).eval()
 
     with torchtrail.trace():
@@ -130,7 +164,14 @@ def test_vit_layer(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTLayer(config).eval()
 
     with torchtrail.trace():
@@ -153,7 +194,14 @@ def test_vit_encoder(tmp_path, show_modules):
     sequence_size = 197
     hidden_size = 768
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTEncoder(config).eval()
 
     with torchtrail.trace():
@@ -180,7 +228,14 @@ def test_vit(tmp_path, show_modules):
     height = 224
     width = 224
 
-    config = transformers.ViTConfig.from_pretrained(model_name)
+    config = transformers.ViTConfig(
+        image_size=224,
+        patch_size=16,
+        num_hidden_layers=12,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_attention_heads=12,
+    )
     model = transformers.models.vit.modeling_vit.ViTModel(config).eval()
 
     with torchtrail.trace():

--- a/torchtrail/codegen.py
+++ b/torchtrail/codegen.py
@@ -52,7 +52,7 @@ def get_module_name(operation):
 
     output = f"{type(module).__name__}"
     if hasattr(module, "torchtrail_name"):
-        if module.torchtrail_name is not "":
+        if module.torchtrail_name != "":
             torchtrail_name = module.torchtrail_name.replace(".", "_")
             return f"{output}_{torchtrail_name}"
     return output


### PR DESCRIPTION
## Summary
- avoid network usage in BERT, ViT, Falcon, and ResNet tests
- fix module name check in `torchtrail.codegen`
- adjust expected graph sizes and codegen line counts

## Testing
- `pytest -q`